### PR TITLE
[ASOC-2016] update asset default version after creating a new asset version

### DIFF
--- a/finite_state_sdk/__init__.py
+++ b/finite_state_sdk/__init__.py
@@ -170,6 +170,34 @@ def create_asset(token, organization_context, business_unit_id=None, created_by_
     response = send_graphql_query(token, organization_context, graphql_query, variables)
     return response['data']
 
+"""
+    Call updateAsset to set the defaultVersion to the newly created AssetVersion
+"""
+def update_asset(token, organization_context, asset_id, asset_version_id):
+    graphql_query = '''
+    mutation UpdateAssetMutation($input: UpdateAssetInput!) {
+        updateAsset(input: $input) {
+            id
+            name
+            defaultVersion {
+                id
+            }
+            versions {
+                id
+            }
+        }
+    }
+    '''
+
+    variables = {
+        "input": {
+            "id": asset_id,
+            "defaultVersion": asset_version_id
+        }
+    }
+
+    response = send_graphql_query(token, organization_context, graphql_query, variables)
+    return response['data']
 
 def create_asset_version(token, organization_context, business_unit_id=None, created_by_user_id=None, asset_id=None, asset_version_name=None, product_id=None):
     """
@@ -246,6 +274,11 @@ def create_asset_version(token, organization_context, business_unit_id=None, cre
         variables["input"]["ctx"]["products"] = product_id
 
     response = send_graphql_query(token, organization_context, graphql_query, variables)
+
+    if response.ok:
+        asset_version_id = response['data']['createAssetVersion']['id']
+        update_asset(token, organization_context, asset_id, asset_version_id)
+
     return response['data']
 
 


### PR DESCRIPTION
Fixes ASOC-2016

When creating a new AssetVersion, we now explicitly call UpdateAsset and set its defaultVersion to the new AssetVersion id in order to properly update that when using the SDK.